### PR TITLE
Changed Chartjs to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "url": "git+https://github.com/fanthos/chartjs-chart-timeline.git"
   },
   "dependencies": {
-    "moment": "^2.22.0",
-    "chart.js": "~2.8.0"
+    "moment": "^2.22.0"
+  },
+  "peerDependencies": {
+    "chart.js": "^2.8.0"
   },
   "devDependencies": {
     "rollup": "^0.58.0",


### PR DESCRIPTION
Currently, when bundling chartjs-chart-timeline, it brings in its own version of chartjs (2.8.0). This means that if a project uses a different version (such as 2.9), both versions are bundled, and the timeline chart is not available from 2.9.

This pull request changes chart.js to a peer dependency, which automatically adopts the chartjs used by the parent project, making only one version of chartjs bundled, and fixing the issue of the chart type not being available.