### PR TITLE
change fallback font to chartjs standard

### DIFF
--- a/src/timeline.js
+++ b/src/timeline.js
@@ -269,7 +269,7 @@ Chart.controllers.timeline = Chart.controllers.bar.extend({
         var font = elemOpts.font;
 
         if (!font) {
-            font = '12px bold Arial';
+            font = 'bold 12px "Helvetica Neue", Helvetica, Arial, sans-serif';
         }
 
         // This one has in account the size of the tick and the height of the bar, so we just


### PR DESCRIPTION
I propose to change the fallback font definition to the ChartJs defaults. If you do not provide vour own font definition, scale labels and labels on the bars are displayed in different fonts. 

Another problem was the ordering of the font definition attributes which resulted in a serif font for bar labels,
"12px bold Arial" should have been "bold 12px Arial"